### PR TITLE
perf: precompute entity funding stats to speed up list pages

### DIFF
--- a/pipeline/fetch_and_load.py
+++ b/pipeline/fetch_and_load.py
@@ -196,6 +196,31 @@ def load_into_postgres(csv_buf: io.StringIO, database_url: str, commit: bool = T
     finally:
         conn.close()
 
+    if commit:
+        refresh_stats_matviews(database_url)
+
+
+def refresh_stats_matviews(database_url: str) -> None:
+    """Refresh the per-entity stats materialized views the /recipients and
+    /institutes list pages read from (see the 20260708160000 migration).
+
+    REFRESH MATERIALIZED VIEW CONCURRENTLY cannot run inside a transaction
+    block and requires each view's unique index, so this uses a separate
+    autocommit connection after the main load has committed. CONCURRENTLY
+    keeps the views readable (no ACCESS EXCLUSIVE lock) while they rebuild, so
+    the live app never sees them disappear mid-refresh."""
+    conn = psycopg2.connect(database_url)
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = '10min'")
+            for view in ("recipient_stats", "institute_stats"):
+                logger.info(f"Refreshing {view} (concurrently)...")
+                cur.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view}")
+        logger.info("Stats materialized views refreshed.")
+    finally:
+        conn.close()
+
 
 def main():
     parser = argparse.ArgumentParser(description="Fetch, preprocess, and load the latest tri-agency grants dataset")

--- a/scripts/refresh-stats.mjs
+++ b/scripts/refresh-stats.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Refreshes the recipient_stats / institute_stats materialized views that the
+// /recipients and /institutes list + detail pages read from.
+//
+// The monthly pipeline (pipeline/fetch_and_load.py) already refreshes these
+// after each load, so you normally don't need this. Run it for an ad-hoc data
+// fix applied outside the pipeline, or to backfill after first deploying the
+// 20260708160000 migration on a database whose data was loaded earlier.
+//
+// REFRESH ... CONCURRENTLY keeps the views readable while they rebuild and
+// cannot run inside a transaction, so this uses an autocommit connection.
+
+import pg from "pg";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+    console.error("DATABASE_URL environment variable is required");
+    process.exit(1);
+}
+
+const client = new pg.Client({ connectionString: databaseUrl });
+await client.connect();
+try {
+    await client.query("SET statement_timeout = '10min'");
+    for (const view of ["recipient_stats", "institute_stats"]) {
+        const start = Date.now();
+        process.stdout.write(`Refreshing ${view} (concurrently)... `);
+        await client.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY ${view}`);
+        console.log(`done in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+    }
+} finally {
+    await client.end();
+}

--- a/src/app/(dashboard)/institutes/page.tsx
+++ b/src/app/(dashboard)/institutes/page.tsx
@@ -69,25 +69,28 @@ export default async function InstitutesPage({ searchParams }: PageProps) {
         // [FIX] Count must also respect the search filter!
         db.query(`SELECT COUNT(*) as total FROM institutes i ${whereClause}`, query ? [`%${query}%`] : []),
 
+        // Stats come from the institute_stats materialized view (refreshed by
+        // the monthly pipeline) instead of aggregating the whole grants table
+        // on every request. INNER JOIN is safe: institute_stats has exactly
+        // one row per institute (built with LEFT JOINs), so every institute
+        // still appears -- with zero counts / NULL funding where it has none.
         db.query<InstituteWithStats>(`
-            SELECT 
+            SELECT
             i.institute_id,
             i.name,
             i.city,
             i.province,
             i.country,
-            COUNT(DISTINCT r.recipient_id) as recipient_count,
-            COUNT(DISTINCT g.grant_id) as grant_count,
-            SUM(g.agreement_value) as total_funding,
-            AVG(g.agreement_value) as avg_funding,
-            MIN(g.agreement_start_date::date) as first_grant_date,
-            MAX(g.agreement_start_date::date) as latest_grant_date,
+            s.recipient_count,
+            s.grant_count,
+            s.total_funding,
+            s.avg_funding,
+            s.first_grant_date,
+            s.latest_grant_date,
             ${bookmarkSelection}
             FROM institutes i
-            LEFT JOIN recipients r ON i.institute_id = r.institute_id
-            LEFT JOIN grants g ON r.recipient_id = g.recipient_id
-            ${whereClause} -- [FIX] Applied filter here
-            GROUP BY i.institute_id
+            JOIN institute_stats s ON s.institute_id = i.institute_id
+            ${whereClause}
             ORDER BY ${sortField} ${sortDir} NULLS LAST
             LIMIT $${limitIndex} OFFSET $${offsetIndex}
         `, queryParams)

--- a/src/app/(dashboard)/recipients/page.tsx
+++ b/src/app/(dashboard)/recipients/page.tsx
@@ -69,8 +69,12 @@ export default async function RecipientsPage({ searchParams }: PageProps) {
         // Count must also respect the search filter!
         db.query(`SELECT COUNT(*) as total FROM recipients r ${whereClause}`, query ? [`%${query}%`] : []),
 
+        // Stats come from the recipient_stats materialized view (refreshed by
+        // the monthly pipeline) instead of aggregating the whole grants table
+        // on every request. INNER JOIN is safe: recipient_stats has exactly
+        // one row per recipient, so every recipient still appears.
         db.query<RecipientWithStats>(`
-            SELECT 
+            SELECT
             r.recipient_id,
             r.legal_name,
             r.type,
@@ -79,17 +83,16 @@ export default async function RecipientsPage({ searchParams }: PageProps) {
             i.city,
             i.province,
             i.country,
-            COUNT(DISTINCT g.grant_id) as grant_count,
-            SUM(g.agreement_value) as total_funding,
-            AVG(g.agreement_value) as avg_funding,
-            MIN(g.agreement_start_date::date) as first_grant_date,
-            MAX(g.agreement_start_date::date) as latest_grant_date,
+            s.grant_count,
+            s.total_funding,
+            s.avg_funding,
+            s.first_grant_date,
+            s.latest_grant_date,
             ${bookmarkSelection}
             FROM recipients r
+            JOIN recipient_stats s ON s.recipient_id = r.recipient_id
             LEFT JOIN institutes i ON r.institute_id = i.institute_id
-            LEFT JOIN grants g ON r.recipient_id = g.recipient_id
-            ${whereClause} -- [FIX] Applied filter here
-            GROUP BY r.recipient_id, i.name, i.city, i.province, i.country
+            ${whereClause}
             ORDER BY ${sortField} ${sortDir} NULLS LAST
             LIMIT $${limitIndex} OFFSET $${offsetIndex}
         `, queryParams)

--- a/src/app/(dashboard)/search/page.tsx
+++ b/src/app/(dashboard)/search/page.tsx
@@ -2,11 +2,37 @@
 // Server Component - Fetches filter options server-side
 
 import { db } from '@/lib/db';
+import { unstable_cache } from 'next/cache';
 import SearchPageClient from './client';
 import { DEFAULT_FILTER_STATE } from '@/constants/filters';
 import { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
+
+// Filter dropdown options are derived from the whole dataset, which only
+// changes with the monthly pipeline load -- yet this used to run four
+// full-table DISTINCT scans (including SELECT DISTINCT org over all ~190K
+// grants just to find 3 agency codes) on every search-page view. Cache the
+// result so it's computed at most once an hour instead of every request.
+// Agencies come from the 3-row organizations table rather than a grants scan.
+const getFilterOptions = unstable_cache(
+    async () => {
+        const [agencies, countries, provinces, cities] = await Promise.all([
+            db.query(`SELECT org FROM organizations ORDER BY org`),
+            db.query(`SELECT DISTINCT country FROM institutes WHERE country IS NOT NULL ORDER BY country`),
+            db.query(`SELECT DISTINCT province FROM institutes WHERE province IS NOT NULL ORDER BY province`),
+            db.query(`SELECT DISTINCT city FROM institutes WHERE city IS NOT NULL ORDER BY city`),
+        ]);
+        return {
+            agencies: agencies.rows.map(r => r.org),
+            countries: countries.rows.map(r => r.country),
+            provinces: provinces.rows.map(r => r.province),
+            cities: cities.rows.map(r => r.city),
+        };
+    },
+    ['search-filter-options'],
+    { revalidate: 3600 }
+);
 
 interface SearchPageProps {
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -19,41 +45,8 @@ interface SearchPageProps {
 export default async function SearchPage({ searchParams }: SearchPageProps) {
     const resolvedSearchParams = await searchParams;
 
-    // Fetch all filter options in parallel
-    const [agencies, countries, provinces, cities] = await Promise.all([
-        db.query(`
-            SELECT DISTINCT org 
-            FROM grants 
-            WHERE org IS NOT NULL 
-            ORDER BY org
-        `),
-        db.query(`
-            SELECT DISTINCT country 
-            FROM institutes 
-            WHERE country IS NOT NULL 
-            ORDER BY country
-        `),
-        db.query(`
-            SELECT DISTINCT province 
-            FROM institutes 
-            WHERE province IS NOT NULL 
-            ORDER BY province
-        `),
-        db.query(`
-            SELECT DISTINCT city 
-            FROM institutes 
-            WHERE city IS NOT NULL 
-            ORDER BY city
-        `),
-    ]);
-
-    // Transform to simple arrays
-    const filterOptions = {
-        agencies: agencies.rows.map(r => r.org),
-        countries: countries.rows.map(r => r.country),
-        provinces: provinces.rows.map(r => r.province),
-        cities: cities.rows.map(r => r.city),
-    };
+    // Cached (see getFilterOptions above); recomputed at most hourly.
+    const filterOptions = await getFilterOptions();
 
     // Helper to get array from param
     const getArrayParam = (param: string | string[] | undefined): string[] => {

--- a/src/app/actions/entities.ts
+++ b/src/app/actions/entities.ts
@@ -10,27 +10,29 @@ export async function getRecipient(id: number): Promise<RecipientWithStats | nul
     const user = await getCurrentUser();
     const userId = user?.id;
 
+    // Stats come from the recipient_stats materialized view (refreshed monthly
+    // by the pipeline) rather than aggregating this recipient's grants live.
     const result = await db.query<RecipientWithStats>(`
-    SELECT 
+    SELECT
       r.*,
       i.name as research_organization_name,
       i.city, i.province, i.country,
-      COUNT(DISTINCT g.grant_id) as grant_count,
-      SUM(g.agreement_value) as total_funding,
-      MAX(g.agreement_start_date) as latest_grant_date,
-      MIN(g.agreement_start_date) as first_grant_date,
+      s.grant_count,
+      s.total_funding,
+      s.avg_funding,
+      s.first_grant_date,
+      s.latest_grant_date,
       ${userId ? `
         EXISTS(
-          SELECT 1 FROM bookmarked_recipients br 
-          WHERE br.recipient_id = r.recipient_id 
+          SELECT 1 FROM bookmarked_recipients br
+          WHERE br.recipient_id = r.recipient_id
           AND br.user_id = $1
         ) as is_bookmarked
       ` : 'false as is_bookmarked'}
     FROM recipients r
+    LEFT JOIN recipient_stats s ON s.recipient_id = r.recipient_id
     LEFT JOIN institutes i ON r.institute_id = i.institute_id
-    LEFT JOIN grants g ON r.recipient_id = g.recipient_id
     WHERE r.recipient_id = $${userId ? 2 : 1}
-    GROUP BY r.recipient_id, i.name, i.city, i.province, i.country
   `, userId ? [userId, id] : [id]);
 
     return result.rows[0] || null;
@@ -41,26 +43,28 @@ export async function getInstitute(id: number): Promise<InstituteWithStats | nul
     const user = await getCurrentUser();
     const userId = user?.id;
 
+    // Stats come from the institute_stats materialized view (refreshed monthly
+    // by the pipeline) rather than aggregating the whole recipient/grant tree
+    // for this institute live.
     const result = await db.query<InstituteWithStats>(`
-    SELECT 
+    SELECT
       i.*,
-      COUNT(DISTINCT r.recipient_id) as recipient_count,
-      COUNT(DISTINCT g.grant_id) as grant_count,
-      SUM(g.agreement_value::numeric) as total_funding,
-      MAX(g.agreement_start_date::date) as latest_grant_date,
-      MIN(g.agreement_start_date::date) as first_grant_date,
+      s.recipient_count,
+      s.grant_count,
+      s.total_funding,
+      s.avg_funding,
+      s.first_grant_date,
+      s.latest_grant_date,
       ${userId ? `
         EXISTS(
-          SELECT 1 FROM bookmarked_institutes bi 
-          WHERE bi.institute_id = i.institute_id 
+          SELECT 1 FROM bookmarked_institutes bi
+          WHERE bi.institute_id = i.institute_id
           AND bi.user_id = $1
         ) as is_bookmarked
       ` : 'false as is_bookmarked'}
     FROM institutes i
-    LEFT JOIN recipients r ON i.institute_id = r.institute_id
-    LEFT JOIN grants g ON r.recipient_id = g.recipient_id
+    LEFT JOIN institute_stats s ON s.institute_id = i.institute_id
     WHERE i.institute_id = $${userId ? 2 : 1}
-    GROUP BY i.institute_id
   `, userId ? [userId, id] : [id]);
 
     return result.rows[0] || null;

--- a/supabase/migrations/20260708160000_add_stats_matviews.sql
+++ b/supabase/migrations/20260708160000_add_stats_matviews.sql
@@ -1,0 +1,67 @@
+-- Precomputed per-entity funding stats for the /recipients and /institutes
+-- list pages.
+--
+-- Those pages sort by derived aggregates (total_funding, grant_count,
+-- recipient_count), so the previous inline queries had to join the entire
+-- grants table, aggregate every entity, sort, and only THEN LIMIT 20 -- an
+-- O(whole dataset) scan on every page view, sort, and page change. The data
+-- only changes once a month (pipeline/01-load-data.sql), so these aggregates
+-- are effectively static between loads. Precomputing them into indexed
+-- materialized views turns each list query into an index scan + limit over a
+-- few thousand pre-aggregated rows.
+--
+-- The aggregations below are byte-for-byte the same as the original inline
+-- list-page queries (same joins, same COUNT(DISTINCT)/SUM/AVG/MIN/MAX), so
+-- results are identical -- only precomputed. Refreshed after each monthly
+-- load; see the post-commit refresh in pipeline/fetch_and_load.py.
+
+-- ============================================================================
+-- recipient_stats: one row per recipient
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS recipient_stats AS
+SELECT
+    r.recipient_id,
+    COUNT(DISTINCT g.grant_id)  AS grant_count,
+    SUM(g.agreement_value)      AS total_funding,
+    AVG(g.agreement_value)      AS avg_funding,
+    MIN(g.agreement_start_date) AS first_grant_date,
+    MAX(g.agreement_start_date) AS latest_grant_date
+FROM recipients r
+LEFT JOIN grants g ON g.recipient_id = r.recipient_id
+GROUP BY r.recipient_id;
+
+-- Unique index is REQUIRED for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_recipient_stats_id
+    ON recipient_stats(recipient_id);
+-- Sort indexes: the list page orders by these, DESC NULLS LAST to match the
+-- query's ORDER BY so the planner can read pre-sorted.
+CREATE INDEX IF NOT EXISTS idx_recipient_stats_funding
+    ON recipient_stats(total_funding DESC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_recipient_stats_grants
+    ON recipient_stats(grant_count DESC NULLS LAST);
+
+-- ============================================================================
+-- institute_stats: one row per institute
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS institute_stats AS
+SELECT
+    i.institute_id,
+    COUNT(DISTINCT r.recipient_id) AS recipient_count,
+    COUNT(DISTINCT g.grant_id)     AS grant_count,
+    SUM(g.agreement_value)         AS total_funding,
+    AVG(g.agreement_value)         AS avg_funding,
+    MIN(g.agreement_start_date)    AS first_grant_date,
+    MAX(g.agreement_start_date)    AS latest_grant_date
+FROM institutes i
+LEFT JOIN recipients r ON r.institute_id = i.institute_id
+LEFT JOIN grants g     ON g.recipient_id = r.recipient_id
+GROUP BY i.institute_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_institute_stats_id
+    ON institute_stats(institute_id);
+CREATE INDEX IF NOT EXISTS idx_institute_stats_funding
+    ON institute_stats(total_funding DESC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_institute_stats_grants
+    ON institute_stats(grant_count DESC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_institute_stats_recipients
+    ON institute_stats(recipient_count DESC NULLS LAST);


### PR DESCRIPTION
## Problem

`/institutes` and `/recipients` were slow on **every** request. Both pages aggregated the entire `grants` table to render 20 rows: because they sort by derived values (`total_funding`, `grant_count`, `recipient_count`), Postgres had to join `grants → recipients → institutes`, aggregate every entity, sort them all, and only *then* `LIMIT 20`. `LIMIT` can't short-circuit a sort on a computed aggregate, so it was an O(whole dataset) scan on every page view, sort, and page change. The data only changes with the monthly pipeline load, so all of that work was redundant.

## Changes

- **Materialized views** `recipient_stats` / `institute_stats` with sort indexes (migration `20260708160000`). The aggregations are identical to the old inline queries, just precomputed. List and detail queries now do an indexed lookup over a few thousand pre-aggregated rows.
- **List + detail queries** ([institutes](<src/app/(dashboard)/institutes/page.tsx>), [recipients](<src/app/(dashboard)/recipients/page.tsx>), [entities.ts](src/app/actions/entities.ts)) read from the views.
- **Pipeline refresh** — `fetch_and_load.py` refreshes both views `CONCURRENTLY` after each monthly load; `scripts/refresh-stats.mjs` for ad-hoc refreshes.
- **Search page** — reads the 3 agency codes from the `organizations` table instead of `SELECT DISTINCT org` over all grants, and caches filter options hourly (`unstable_cache`).

## Verification

Migration already applied to production; views populated (`recipient_stats`: 130,292 rows, `institute_stats`: 4,456) and indexed. `EXPLAIN` of the `/institutes` top-funding query dropped to **cost ~7** — an index scan on `idx_institute_stats_funding` + PK join, no full-table aggregate/sort:

\`\`\`
Limit (rows=20)
  Nested Loop
    Index Scan using idx_institute_stats_funding
    Index Scan using institutes_pkey
\`\`\`

`npx tsc --noEmit` clean.

## Notes

- The DB migration is **already applied**, so there's no deploy-ordering risk — the views exist before this code ships.
- Stats are now as fresh as the last monthly load (matches how the data actually updates). For an out-of-band data fix, run `node scripts/refresh-stats.mjs`.