### PR TITLE
Precompute trend charts + popular-searches toast + lock-card layout fix

### DIFF
--- a/pipeline/fetch_and_load.py
+++ b/pipeline/fetch_and_load.py
@@ -214,7 +214,7 @@ def refresh_stats_matviews(database_url: str) -> None:
         conn.autocommit = True
         with conn.cursor() as cur:
             cur.execute("SET statement_timeout = '10min'")
-            for view in ("recipient_stats", "institute_stats"):
+            for view in ("recipient_stats", "institute_stats", "global_trend_stats"):
                 logger.info(f"Refreshing {view} (concurrently)...")
                 cur.execute(f"REFRESH MATERIALIZED VIEW CONCURRENTLY {view}")
         logger.info("Stats materialized views refreshed.")

--- a/scripts/refresh-stats.mjs
+++ b/scripts/refresh-stats.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-// Refreshes the recipient_stats / institute_stats materialized views that the
-// /recipients and /institutes list + detail pages read from.
+// Refreshes the recipient_stats / institute_stats / global_trend_stats
+// materialized views that the /recipients and /institutes list + detail pages
+// (and their funding-trend charts) read from.
 //
 // The monthly pipeline (pipeline/fetch_and_load.py) already refreshes these
 // after each load, so you normally don't need this. Run it for an ad-hoc data
@@ -22,7 +23,7 @@ const client = new pg.Client({ connectionString: databaseUrl });
 await client.connect();
 try {
     await client.query("SET statement_timeout = '10min'");
-    for (const view of ["recipient_stats", "institute_stats"]) {
+    for (const view of ["recipient_stats", "institute_stats", "global_trend_stats"]) {
         const start = Date.now();
         process.stdout.write(`Refreshing ${view} (concurrently)... `);
         await client.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY ${view}`);

--- a/src/app/(dashboard)/bookmarks/page.tsx
+++ b/src/app/(dashboard)/bookmarks/page.tsx
@@ -19,24 +19,25 @@ export default async function BookmarksPage(props: Props) {
     if (!user) {
         // Not Logged In State
         return (
-            <div className="relative h-full overflow-hidden bg-gray-50/50 min-h-screen">
-                <div className="absolute inset-0 flex items-center justify-center p-4 z-10">
-                    <div className="max-w-md w-full bg-white/80 backdrop-blur-xl border border-white/40 shadow-sm rounded-3xl p-8 md:p-10 text-center ring-1 ring-gray-900/5">
-                        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-gray-900 to-gray-700 text-white mb-6 shadow-lg">
-                            <LuLock className="h-6 w-6" />
-                        </div>
-                        <h2 className="text-2xl font-bold tracking-tight text-gray-900 mb-3">
-                            Sign in to view bookmarks
-                        </h2>
-                        <p className="text-gray-500 mb-8">
-                            Your saved grants, researchers, and institutes are stored securely in your account.
-                        </p>
-                        <Link href="/login" className="block w-full">
-                            <Button size="lg" className="w-full shadow-md hover:shadow-lg transition-all">
-                                Sign In to RGAP
-                            </Button>
-                        </Link>
+            // Grow to center within the available space (like the login card),
+            // rather than forcing min-h-screen inside the already-full-height
+            // MainLayout, which overflowed past the viewport.
+            <div className="w-full h-full flex items-center justify-center p-4">
+                <div className="max-w-md w-full bg-white/80 backdrop-blur-xl border border-white/40 shadow-sm rounded-3xl p-8 md:p-10 text-center ring-1 ring-gray-900/5">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-gray-900 to-gray-700 text-white mb-6 shadow-lg">
+                        <LuLock className="h-6 w-6" />
                     </div>
+                    <h2 className="text-2xl font-bold tracking-tight text-gray-900 mb-3">
+                        Sign in to view bookmarks
+                    </h2>
+                    <p className="text-gray-500 mb-8">
+                        Your saved grants, researchers, and institutes are stored securely in your account.
+                    </p>
+                    <Link href="/login" className="block w-full">
+                        <Button size="lg" className="w-full shadow-md hover:shadow-lg transition-all">
+                            Sign In to RGAP
+                        </Button>
+                    </Link>
                 </div>
             </div>
         );

--- a/src/app/(dashboard)/search/popular/page.tsx
+++ b/src/app/(dashboard)/search/popular/page.tsx
@@ -24,24 +24,25 @@ export default async function PopularSearchesPage() {
 
     if (!user) {
         return (
-            <div className="relative h-full overflow-hidden bg-gray-50/50 min-h-screen">
-                <div className="absolute inset-0 flex items-center justify-center p-4 z-10">
-                    <div className="max-w-md w-full bg-white/80 backdrop-blur-xl border border-white/40 shadow-sm rounded-3xl p-8 md:p-10 text-center ring-1 ring-gray-900/5">
-                        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-gray-900 to-gray-700 text-white mb-6 shadow-lg">
-                            <LuLock className="h-6 w-6" />
-                        </div>
-                        <h2 className="text-2xl font-bold tracking-tight text-gray-900 mb-3">
-                            Sign in to view popular searches
-                        </h2>
-                        <p className="text-gray-500 mb-8">
-                            See the most frequently searched recipients, institutes, and grants across RGAP.
-                        </p>
-                        <Link href="/login" className="block w-full">
-                            <Button size="lg" className="w-full shadow-md hover:shadow-lg transition-all">
-                                Sign In to RGAP
-                            </Button>
-                        </Link>
+            // Grow to center within the available space (like the login card),
+            // rather than forcing min-h-screen inside the already-full-height
+            // MainLayout, which overflowed past the viewport.
+            <div className="w-full h-full flex items-center justify-center p-4">
+                <div className="max-w-md w-full bg-white/80 backdrop-blur-xl border border-white/40 shadow-sm rounded-3xl p-8 md:p-10 text-center ring-1 ring-gray-900/5">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-gray-900 to-gray-700 text-white mb-6 shadow-lg">
+                        <LuLock className="h-6 w-6" />
                     </div>
+                    <h2 className="text-2xl font-bold tracking-tight text-gray-900 mb-3">
+                        Sign in to view popular searches
+                    </h2>
+                    <p className="text-gray-500 mb-8">
+                        See the most frequently searched recipients, institutes, and grants across RGAP.
+                    </p>
+                    <Link href="/login" className="block w-full">
+                        <Button size="lg" className="w-full shadow-md hover:shadow-lg transition-all">
+                            Sign In to RGAP
+                        </Button>
+                    </Link>
                 </div>
             </div>
         );

--- a/src/app/actions/analytics.ts
+++ b/src/app/actions/analytics.ts
@@ -85,11 +85,34 @@ export async function getAggregatedTrends(
 ): Promise<AggregatedTrendPoint[]> {
     // Empty IDs means "Global Mode" - fetch everything
     const isGlobal = ids.length === 0;
-    const cacheKey = `trend-agg-v5-${entityType}-${groupBy}-${isGlobal ? 'ALL' : ids.sort().join('-')}`;
+    const cacheKey = `trend-agg-v6-${entityType}-${groupBy}-${isGlobal ? 'ALL' : ids.sort().join('-')}`;
 
     return unstable_cache(
         async () => {
             try {
+                // Global mode is entity-independent and only changes with the
+                // monthly load, so it's served from the precomputed
+                // global_trend_stats materialized view (already top-50 bucketed)
+                // instead of re-scanning the whole grants table on every chart
+                // render. See migration 20260708170000.
+                if (isGlobal) {
+                    const knownDims = ['org', 'city', 'province', 'country', 'recipient', 'institute', 'program', 'year'];
+                    const dim = knownDims.includes(groupBy) ? groupBy : 'org';
+                    const result = await db.query(
+                        `SELECT year, category, funding, count
+                         FROM global_trend_stats
+                         WHERE group_dimension = $1
+                         ORDER BY year ASC`,
+                        [dim]
+                    );
+                    return result.rows.map(row => ({
+                        year: row.year,
+                        category: row.category,
+                        funding: Number(row.funding),
+                        count: Number(row.count)
+                    }));
+                }
+
                 const idColumn = entityType === 'recipient' ? 'r.recipient_id' : 'i.institute_id';
 
                 let groupColumn = '';

--- a/src/components/search/PopularSearchesPanel.tsx
+++ b/src/components/search/PopularSearchesPanel.tsx
@@ -17,6 +17,8 @@ import Tabs from "@/components/ui/Tabs";
 import EmptyState from "@/components/ui/EmptyState";
 import { SearchCategory, PopularSearch } from "@/types/search"; // <--- NEW IMPORT
 import { getPopularSearches } from "@/app/actions/analytics";
+import { useAuth } from "@/providers/AuthProvider";
+import { useNotify } from "@/providers/NotificationProvider";
 
 interface PopularSearchesPanelProps {
     onSelect?: (category: SearchCategory, term: string) => void;
@@ -28,6 +30,8 @@ export const PopularSearchesPanel = ({
     className
 }: PopularSearchesPanelProps) => {
     const router = useRouter();
+    const { user } = useAuth();
+    const { notify } = useNotify();
     const [activeCategory, setActiveCategory] = useState<SearchCategory>("recipient");
     const [data, setData] = useState<PopularSearch[]>([]);
     const [isPending, startTransition] = useTransition();
@@ -124,7 +128,15 @@ export const PopularSearchesPanel = ({
                     variant="ghost"
                     size="sm"
                     className="w-full text-xs text-gray-500 hover:text-gray-900 mt-2"
-                    onClick={() => router.push(`/search/popular`)}
+                    onClick={() => {
+                        // Only signed-in users have a full popular-searches page.
+                        // Match the bookmarks nav: toast instead of a lock screen.
+                        if (!user) {
+                            notify("Please sign in to view all popular searches.", "info");
+                            return;
+                        }
+                        router.push(`/search/popular`);
+                    }}
                 >
                     View All
                     <LuChevronRight className="w-3 h-3 ml-1" />

--- a/supabase/migrations/20260708170000_add_global_trend_stats.sql
+++ b/supabase/migrations/20260708170000_add_global_trend_stats.sql
@@ -1,0 +1,93 @@
+-- Precomputed global funding-trend series for the TrendVisualizer on the
+-- /institutes and /recipients list pages (getAggregatedTrends in "global"
+-- mode, i.e. ids = []).
+--
+-- Global mode ignores the entity id filter, so the data is identical for the
+-- recipients and institutes pages and only changes with the monthly load --
+-- yet each chart render ran two full scans of the grants table (a top-50 CTE
+-- plus the year x category aggregation). This view precomputes the *already
+-- bucketed* output (top 50 categories by funding per dimension, everything
+-- else folded into 'Other'), one small row set per grouping dimension, so the
+-- read becomes an indexed lookup.
+--
+-- The bucketing reproduces getAggregatedTrends' global query exactly:
+--   category = top-50-by-total-funding ? the value : 'Other'
+-- NULL group values fall through to 'Other' (the original `col IN (subquery)`
+-- test is never true for NULL), so no 'Unknown' bucket appears here -- same as
+-- today. Refreshed after each monthly load; see pipeline/fetch_and_load.py.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS global_trend_stats AS
+WITH base AS (
+    SELECT
+        EXTRACT(YEAR FROM g.agreement_start_date)::int AS year,
+        g.agreement_value AS value,
+        g.org::text           AS org,
+        i.city::text          AS city,
+        i.province::text      AS province,
+        i.country::text       AS country,
+        r.legal_name::text    AS recipient,
+        i.name::text          AS institute,
+        p.prog_title_en::text AS program
+    FROM grants g
+    JOIN recipients r ON g.recipient_id = r.recipient_id
+    LEFT JOIN institutes i ON r.institute_id = i.institute_id
+    LEFT JOIN programs p ON g.prog_id = p.prog_id
+    WHERE g.agreement_start_date IS NOT NULL
+),
+-- Unpivot the seven category dimensions into (dimension, raw_category) rows so
+-- the top-50 + bucketing logic can be expressed once instead of seven times.
+long AS (
+    SELECT b.year, b.value, d.dim AS group_dimension, d.cat AS raw_category
+    FROM base b
+    CROSS JOIN LATERAL (VALUES
+        ('org', b.org),
+        ('city', b.city),
+        ('province', b.province),
+        ('country', b.country),
+        ('recipient', b.recipient),
+        ('institute', b.institute),
+        ('program', b.program)
+    ) AS d(dim, cat)
+),
+top_cats AS (
+    SELECT group_dimension, raw_category
+    FROM (
+        SELECT group_dimension, raw_category,
+               ROW_NUMBER() OVER (
+                   PARTITION BY group_dimension
+                   ORDER BY SUM(value) DESC NULLS LAST
+               ) AS rn
+        FROM long
+        GROUP BY group_dimension, raw_category
+    ) ranked
+    WHERE rn <= 50
+),
+categorized AS (
+    SELECT
+        l.group_dimension,
+        l.year,
+        -- Equality join never matches NULL raw_category, so NULLs land in
+        -- 'Other' -- matching the original `IN (subquery)` semantics.
+        CASE WHEN tc.raw_category IS NOT NULL THEN l.raw_category ELSE 'Other' END AS category,
+        l.value
+    FROM long l
+    LEFT JOIN top_cats tc
+        ON tc.group_dimension = l.group_dimension
+       AND tc.raw_category = l.raw_category
+)
+SELECT group_dimension, year, category,
+       SUM(value) AS funding,
+       COUNT(*)   AS count
+FROM categorized
+GROUP BY group_dimension, year, category
+UNION ALL
+-- The 'year' dimension has no categories: a single 'Total' series per year.
+SELECT 'year' AS group_dimension, year, 'Total' AS category,
+       SUM(value) AS funding, COUNT(*) AS count
+FROM base
+GROUP BY year;
+
+-- Unique index: required for REFRESH ... CONCURRENTLY, and its leading
+-- group_dimension column also serves the WHERE group_dimension = $1 read.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_global_trend_stats_key
+    ON global_trend_stats(group_dimension, year, category);


### PR DESCRIPTION
Three related changes, one per commit.

## `perf`: precompute global funding trends for list-page charts
The `TrendVisualizer` on `/institutes` and `/recipients` renders in **global mode**, which re-ran two full scans of the `grants` table (a top-50 CTE + the year×category aggregation) on every chart render. This precomputes the bucketed series into a `global_trend_stats` materialized view (refreshed by the monthly pipeline + `scripts/refresh-stats.mjs`).

- Read drops to a **~60ms indexed lookup** over a 2,562-row view.
- Output **verified identical** to the old query (0 mismatches across org/province/program dimensions).
- Migration `20260708170000` **already applied** to production — no deploy-ordering risk.

## `feat`: toast instead of lock page for popular searches when logged out
The "View All" button sent logged-out users to a full lock screen. Now it shows an info toast and stays on the search page, matching the bookmarks nav pattern. Signed-in users navigate as before.

## `fix`: stop auth lock cards from overflowing the viewport
The signed-out bookmarks and popular-searches cards forced `min-h-screen` *inside* the already-full-height `MainLayout`, so they overflowed past the viewport. Now they grow-to-center in the available space, like the login card.