### PR TITLE
perf: server-preload the default list-page trend chart

### DIFF
--- a/src/components/entity/EntitiesPage.tsx
+++ b/src/components/entity/EntitiesPage.tsx
@@ -6,6 +6,11 @@ import { EntityCard } from "@/components/entity/EntityCard";
 import { IconType } from "react-icons";
 import { EntityType, InstituteWithStats, RecipientWithStats, SortOption } from "@/types/database";
 import { TrendVisualizer } from "@/components/visualizations/TrendVisualizer";
+import { getAggregatedTrends } from "@/app/actions/analytics";
+
+// The list-page chart defaults to grouping by funding agency; preload that view
+// server-side so it paints with data instead of a client-side fetch waterfall.
+const DEFAULT_TREND_GROUPING = "org";
 
 interface EntitiesPageProps {
     title: string;
@@ -20,7 +25,7 @@ interface EntitiesPageProps {
     page: number;
 }
 
-const EntitiesPage = ({
+const EntitiesPage = async ({
     title,
     subtitle,
     icon,
@@ -39,6 +44,17 @@ const EntitiesPage = ({
             : (entity as InstituteWithStats).institute_id
     );
 
+    // Only recipients/institutes get the funding-trend chart.
+    const vizEntityType =
+        (entityType === 'recipient' || entityType === 'institute') ? entityType : null;
+    const showViz = showVisualization && entities.length > 0 && vizEntityType !== null;
+
+    // Preload the default (global) grouping so the chart renders immediately.
+    // Served from the global_trend_stats materialized view, so this is cheap.
+    const trendData = showViz && vizEntityType
+        ? await getAggregatedTrends(vizEntityType, [], DEFAULT_TREND_GROUPING)
+        : undefined;
+
     return (
         <PageContainer className="space-y-6">
             <PageHeader
@@ -47,10 +63,12 @@ const EntitiesPage = ({
                 icon={icon}
             />
 
-            {showVisualization && entities.length > 0 && (entityType === 'recipient' || entityType === 'institute') && (
+            {showViz && vizEntityType && (
                 <TrendVisualizer
-                    entityType={entityType}
+                    entityType={vizEntityType}
                     title={`${title} Funding Trends`}
+                    preLoadedData={trendData}
+                    initialGrouping={DEFAULT_TREND_GROUPING}
                 />
             )}
 

--- a/src/components/visualizations/TrendVisualizer.tsx
+++ b/src/components/visualizations/TrendVisualizer.tsx
@@ -1,7 +1,7 @@
 // src/components/visualizations/TrendVisualizer.tsx
 'use client';
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
     LuDollarSign, LuHash, LuChartColumnStacked, LuChartColumn,
     LuChartSpline, LuActivity, LuLandmark, LuGraduationCap,
@@ -117,10 +117,14 @@ export const TrendVisualizer: React.FC<TrendVisualizerProps> = ({
     const [isRefetching, setIsRefetching] = useState(false);
     const [error, setError] = useState(false);
 
+    // preLoadedData covers only the initial grouping (painted server-side).
+    // Track the first effect run so a grouping change still triggers a fetch.
+    const isFirstEffectRun = useRef(true);
+
     // --- 2. Data Fetching & Aggregation ---
     useEffect(() => {
-        // CASE 1: Pre-loaded or Amendment
-        if (preLoadedData || isAmendmentView) {
+        // CASE 1: Amendment history is fully static -- never fetch.
+        if (isAmendmentView) {
             setIsInitialLoading(false);
             return;
         }
@@ -203,6 +207,17 @@ export const TrendVisualizer: React.FC<TrendVisualizerProps> = ({
         if (!entityType) {
             setIsInitialLoading(false);
             return;
+        }
+
+        // The initial grouping was preloaded server-side, so the chart already
+        // has data on first paint -- skip the fetch on the first run only.
+        // Changing the grouping afterwards falls through and fetches normally.
+        if (isFirstEffectRun.current) {
+            isFirstEffectRun.current = false;
+            if (preLoadedData) {
+                setIsInitialLoading(false);
+                return;
+            }
         }
 
         let isMounted = true;


### PR DESCRIPTION
Recovers the 4th commit that landed on `perf/trends-and-ux` **after** PR #2 was already merged, so it never made it into `main`.

## What
The `TrendVisualizer` on `/institutes` and `/recipients` is a client component that only fired its data fetch after mounting, so the chart flashed a spinner on every load. `EntitiesPage` (now async) preloads the default "by agency" grouping server-side from the `global_trend_stats` matview and passes it as `preLoadedData`, so the chart paints with data on first render. `TrendVisualizer` is refactored so preloaded data seeds only the initial paint — changing the grouping still fetches.

## Verified
- `npx tsc --noEmit` clean.
- Previously smoke-tested against the running dev server: `/institutes` and `/recipients` return the chart in the server HTML with no "Analyzing data…" loading state.
- Other `TrendVisualizer` callers (search page, detail analytics, grant amendments) don't pass `preLoadedData`, so they're unaffected.

Builds on the `global_trend_stats` matview already in `main` (and applied to the DB) from PR #2.